### PR TITLE
Stream updates

### DIFF
--- a/Source/CiThruS/Pipeline/Components/HevcEncoder.cpp
+++ b/Source/CiThruS/Pipeline/Components/HevcEncoder.cpp
@@ -1,10 +1,10 @@
 #include "HevcEncoder.h"
 #include "Misc/Debug.h"
 
-const uint64_t KVAZAAR_FRAMERATE_DENOM = 90000;
+#include <algorithm>
 
-HevcEncoder::HevcEncoder(const uint16_t& frameWidth, const uint16_t& frameHeight, const uint8_t& threadCount, const uint8_t& qp, const uint8_t& wpp, const uint8_t& owf, const HevcEncoderPreset& preset)
-	: frameWidth_(frameWidth), frameHeight_(frameHeight), outputData_(nullptr), startTime_(std::chrono::high_resolution_clock::time_point::min())
+HevcEncoder::HevcEncoder(const uint16_t& frameWidth, const uint16_t& frameHeight, const uint8_t& threadCount, const uint8_t& qp, const uint8_t& wpp, const uint8_t& owf, const HevcEncoderPreset& preset, const uint32_t& frameRate)
+	: frameWidth_(frameWidth), frameHeight_(frameHeight), frameRate_(std::max(frameRate, 1u)), outputData_(nullptr)
 {
 #ifdef CITHRUS_KVAZAAR_AVAILABLE
 	// Set up Kvazaar for encoding
@@ -48,8 +48,8 @@ HevcEncoder::HevcEncoder(const uint16_t& frameWidth, const uint16_t& frameHeight
 	kvazaarConfig_->width = frameWidth;
 	kvazaarConfig_->height = frameHeight;
 	kvazaarConfig_->hash = KVZ_HASH_NONE;
-	/*kvazaarConfig_->framerate_num = 1;
-	kvazaarConfig_->framerate_denom = KVAZAAR_FRAMERATE_DENOM;*/
+	kvazaarConfig_->framerate_num = frameRate_;
+	kvazaarConfig_->framerate_denom = 1;
 
 	kvazaarConfig_->aud_enable = 0;
 	kvazaarConfig_->calc_psnr = 0;
@@ -85,14 +85,9 @@ void HevcEncoder::Process()
 
 	if (!inputData || inputSize == 0)
 	{
+		GetOutputPin<0>().SetData(nullptr);
+		GetOutputPin<0>().SetSize(0);
 		return;
-	}
-
-	std::chrono::high_resolution_clock::time_point now = std::chrono::high_resolution_clock::now();
-
-	if (startTime_ == std::chrono::high_resolution_clock::time_point::min())
-	{
-		startTime_ = now;
 	}
 
 	const uint8_t* yuvFrame = inputData;
@@ -104,9 +99,9 @@ void HevcEncoder::Process()
 	yuvFrame += frameWidth_ * frameHeight_ / 4;
 	memcpy(kvazaarTransmitPicture_->v, yuvFrame, frameWidth_ * frameHeight_ / 4);
 
-	// TODO: Something about this doesn't work, causes choppy video. Probably dts since it affects the decoding
-	/*kvazaarTransmitPicture_->pts = ((now - startTime_).count() * KVAZAAR_FRAMERATE_DENOM) / 1000000000ll;
-	kvazaarTransmitPicture_->dts = kvazaarTransmitPicture_->pts;*/
+	kvazaarTransmitPicture_->pts = frameIndex_;
+	kvazaarTransmitPicture_->dts = frameIndex_;
+	frameIndex_++;
 
 	kvz_frame_info frame_info;
 	kvz_data_chunk* data_out = nullptr;

--- a/Source/CiThruS/Pipeline/Components/HevcEncoder.h
+++ b/Source/CiThruS/Pipeline/Components/HevcEncoder.h
@@ -5,7 +5,6 @@
 #include "CoreMinimal.h"
 
 #include <string>
-#include <chrono>
 
 enum HevcEncoderPreset : uint8_t
 {
@@ -18,7 +17,7 @@ enum HevcEncoderPreset : uint8_t
 class CITHRUS_API HevcEncoder : public PipelineFilter<1, 1>
 {
 public:
-	HevcEncoder(const uint16_t& frameWidth, const uint16_t& frameHeight, const uint8_t& threadCount, const uint8_t& qp, const uint8_t& wpp, const uint8_t& owf, const HevcEncoderPreset& preset = HevcPresetNone);
+	HevcEncoder(const uint16_t& frameWidth, const uint16_t& frameHeight, const uint8_t& threadCount, const uint8_t& qp, const uint8_t& wpp, const uint8_t& owf, const HevcEncoderPreset& preset = HevcPresetNone, const uint32_t& frameRate = 60);
 	virtual ~HevcEncoder();
 
 	virtual void Process() override;
@@ -26,10 +25,10 @@ public:
 protected:
 	uint32_t frameWidth_;
 	uint32_t frameHeight_;
+	uint32_t frameRate_;
 
 	uint8_t* outputData_;
-
-	std::chrono::high_resolution_clock::time_point startTime_;
+	int64_t frameIndex_ = 0;
 
 #ifdef CITHRUS_KVAZAAR_AVAILABLE
 	const kvz_api* kvazaarApi_ = kvz_api_get(8);

--- a/Source/CiThruS/Pipeline/Components/RgbaToYuvConverter.cpp
+++ b/Source/CiThruS/Pipeline/Components/RgbaToYuvConverter.cpp
@@ -55,10 +55,14 @@ void RgbaToYuvConverter::Process()
 
     if (!inputData || inputSize != outputFrameWidth_ * outputFrameHeight_ * 4)
     {
+        GetOutputPin<0>().SetData(nullptr);
+        GetOutputPin<0>().SetSize(0);
         return;
     }
 
 	(this->*converterFunction_)(inputData, &outputData_, outputFrameWidth_, outputFrameHeight_);
+    GetOutputPin<0>().SetData(outputData_);
+    GetOutputPin<0>().SetSize(outputFrameWidth_ * outputFrameHeight_ * 3 / 2);
 }
 
 void RgbaToYuvConverter::RgbaToYuvDefault(const uint8_t* input, uint8_t** output, int width, int height)

--- a/Source/CiThruS/Pipeline/Components/RtpTransmitter.cpp
+++ b/Source/CiThruS/Pipeline/Components/RtpTransmitter.cpp
@@ -1,7 +1,7 @@
 #include "RtpTransmitter.h"
 #include "Misc/Debug.h"
 
-RtpTransmitter::RtpTransmitter(const std::string& ip, const int& dstPort)
+RtpTransmitter::RtpTransmitter(const std::string& ip, const int& dstPort, const int& frameRate)
 {
 #ifdef CITHRUS_UVGRTP_AVAILABLE
 	streamSession_ = streamContext_.create_session(ip);
@@ -10,6 +10,11 @@ RtpTransmitter::RtpTransmitter(const std::string& ip, const int& dstPort)
 	if (!stream_)
 	{
 		Debug::Log("Failed to create RTP stream");
+	}
+	else if (frameRate > 0)
+	{
+		stream_->configure_ctx(RCC_FPS_NUMERATOR, frameRate);
+		stream_->configure_ctx(RCC_FPS_DENOMINATOR, 1);
 	}
 #endif // CITHRUS_UVGRTP_AVAILABLE
 

--- a/Source/CiThruS/Pipeline/Components/RtpTransmitter.h
+++ b/Source/CiThruS/Pipeline/Components/RtpTransmitter.h
@@ -11,7 +11,7 @@
 class CITHRUS_API RtpTransmitter : public PipelineSink<1>
 {
 public:
-	RtpTransmitter(const std::string& ip, const int& dstPort);
+	RtpTransmitter(const std::string& ip, const int& dstPort, const int& frameRate = 0);
 	virtual ~RtpTransmitter();
 
 	virtual void Process() override;

--- a/Source/CiThruS/Video/VideoTransmitter.cpp
+++ b/Source/CiThruS/Video/VideoTransmitter.cpp
@@ -14,9 +14,34 @@
 #include "Pipeline/AsyncPipelineRunner.h"
 
 #include "Misc/Debug.h"
+#include "HAL/IConsoleManager.h"
+#include "Engine/Engine.h"
 
 #include <string>
 #include <algorithm>
+
+namespace
+{
+	void ApplyStreamFrameRateLimit(int32 StreamFrameRate)
+	{
+		if (GEngine)
+		{
+			GEngine->bUseFixedFrameRate = true;
+			GEngine->FixedFrameRate = StreamFrameRate;
+			GEngine->SetMaxFPS(StreamFrameRate);
+		}
+
+		if (IConsoleVariable* MaxFps = IConsoleManager::Get().FindConsoleVariable(TEXT("t.MaxFPS")))
+		{
+			MaxFps->Set(static_cast<float>(StreamFrameRate), ECVF_SetByCode);
+		}
+
+		if (IConsoleVariable* VSync = IConsoleManager::Get().FindConsoleVariable(TEXT("r.VSync")))
+		{
+			VSync->Set(0, ECVF_SetByCode);
+		}
+	}
+}
 
 AVideoTransmitter::AVideoTransmitter()
 {
@@ -71,9 +96,8 @@ void AVideoTransmitter::PostRegisterAllComponents()
 
 void AVideoTransmitter::EndPlay(const EEndPlayReason::Type endPlayReason)
 {
+	StopTransmitInternal();
 	Super::EndPlay(endPlayReason);
-
-	DeleteStreams();
 }
 
 void AVideoTransmitter::Tick(float deltaTime)
@@ -91,6 +115,15 @@ void AVideoTransmitter::Tick(float deltaTime)
 	{
 		return;
 	}
+
+	const double CaptureInterval = 1.0 / streamFrameRate_;
+	captureAccumulator_ += deltaTime;
+	if (captureAccumulator_ < CaptureInterval)
+	{
+		return;
+	}
+
+	captureAccumulator_ = FMath::Min(captureAccumulator_ - CaptureInterval, CaptureInterval);
 
 	if (capture360_)
 	{
@@ -110,12 +143,15 @@ void AVideoTransmitter::Tick(float deltaTime)
 void AVideoTransmitter::StartTransmit()
 {
 	std::lock_guard<std::mutex> lock(streamMutex_);
+	streamFrameRate_ = FMath::Max(streamFrameRate_, 1);
+	ApplyStreamFrameRateLimit(streamFrameRate_);
 
 	if (ResetStreams())
 	{
 		transmitEnabled_ = true;
 		useEditorTick_ = true;
 		wantsStop_ = false;
+		captureAccumulator_ = 0.0;
 	}
 }
 
@@ -185,8 +221,8 @@ bool AVideoTransmitter::StartStreams()
 						new RgbaToYuvConverter(frameWidth, frameHeight),
 						new HevcEncoder(frameWidth, frameHeight,
 							processingThreadCount_, quantizationParameter_, wavefrontParallelProcessing_, overlappedWavefront_,
-							saveToFile_ ? HevcPresetLossless : HevcPresetMinimumLatency),
-						new RtpTransmitter(TCHAR_TO_UTF8(*remoteStreamIp_), remoteVideoDstPort_)));
+							saveToFile_ ? HevcPresetLossless : HevcPresetMinimumLatency, streamFrameRate_),
+						new RtpTransmitter(TCHAR_TO_UTF8(*remoteStreamIp_), remoteVideoDstPort_, streamFrameRate_)));
 			}
 		}
 		else
@@ -214,8 +250,8 @@ bool AVideoTransmitter::StartStreams()
 						new RgbaToYuvConverter(frameWidth, frameHeight),
 						new HevcEncoder(frameWidth, frameHeight,
 							processingThreadCount_, quantizationParameter_, wavefrontParallelProcessing_, overlappedWavefront_,
-							saveToFile_ ? HevcPresetLossless : HevcPresetMinimumLatency),
-						new RtpTransmitter(TCHAR_TO_UTF8(*remoteStreamIp_), remoteVideoDstPort_)));
+							saveToFile_ ? HevcPresetLossless : HevcPresetMinimumLatency, streamFrameRate_),
+						new RtpTransmitter(TCHAR_TO_UTF8(*remoteStreamIp_), remoteVideoDstPort_, streamFrameRate_)));
 			}
 		}
 	}
@@ -256,4 +292,5 @@ void AVideoTransmitter::StopTransmitInternal()
 	transmitEnabled_ = false;
 	useEditorTick_ = false;
 	wantsStop_ = false;
+	captureAccumulator_ = 0.0;
 }

--- a/Source/CiThruS/Video/VideoTransmitter.h
+++ b/Source/CiThruS/Video/VideoTransmitter.h
@@ -49,6 +49,9 @@ public:
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "General Stream Settings")
 	int remoteStreamHeight_ = 720;
 
+	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "General Stream Settings")
+	int streamFrameRate_ = 60;
+
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "Depth Settings")
 	float fov_ = 60.0f;
 
@@ -94,6 +97,7 @@ private:
 	bool capture360_;
 
 	bool useEditorTick_;
+	double captureAccumulator_ = 0.0;
 
 	virtual void PostRegisterAllComponents() override;
 	virtual void EndPlay(const EEndPlayReason::Type endPlayReason) override;

--- a/Source/CiThruS/ViewSynthesis/PubSubCommunicator.cpp
+++ b/Source/CiThruS/ViewSynthesis/PubSubCommunicator.cpp
@@ -6,9 +6,23 @@
 #include "Traffic/Entities/Bicycle.h"
 #include "Traffic/Entities/ITrafficEntity.h"
 #include "Traffic/Parking/ParkingSpace.h"
+#include "Misc/CommandLine.h"
 #include "Misc/GeoUtility.h"
+#include "Misc/Parse.h"
 #include "GeoReferencingSystem.h"
 #include <format>
+
+namespace
+{
+	void ApplyParkedCarsOverride(bool& value)
+	{
+		FString parsedValue;
+		if (FParse::Value(FCommandLine::Get(), TEXT("ParkedCars="), parsedValue))
+		{
+			value = parsedValue.Equals(TEXT("true"), ESearchCase::IgnoreCase);
+		}
+	}
+}
 
 void UPubSubCommunicator::PublishBool(FString topic, bool value)
 {
@@ -92,11 +106,6 @@ void UPubSubCommunicator::PublishTrafficEntity(FString topic, AActor* actor)
 		= "{\n"
 		"\t\"Timestamp\": \"" + std::format("{:%FT%TZ}", now) + "\",\n"
 		"\t\"Vehicle\": {\n"
-		"\t\t\"Powertrain\": {\n"
-		"\t\t\t\"Transmission\": {\n"
-		"\t\t\t\t\"SelectedGear\": " + std::to_string(selectedGear) + "\n"
-		"\t\t\t}\n"
-		"\t\t},\n"
 		"\t\t\"CurrentLocation\": {\n"
 		"\t\t\t\"Latitude\": " + std::format("{:.8f}", geoData.geographicCoordinates.Latitude) + ",\n"
 		"\t\t\t\"Longitude\": " + std::format("{:.8f}", geoData.geographicCoordinates.Longitude) + ",\n"
@@ -161,6 +170,8 @@ void UPubSubCommunicator::PublishTrafficArray(FString topic, const TArray<AActor
 		FVector worldLocation = FVector::ZeroVector;
 		FQuat worldQuat = FQuat::Identity;
 		FVector unrealLinearVelocity = FVector::ZeroVector;
+
+		ApplyParkedCarsOverride(publishParkedCarData_);
 
 		if (AParkingSpace* parkingSpace = Cast<AParkingSpace>(actor))
 		{
@@ -333,6 +344,7 @@ void UPubSubCommunicator::StartMqttClient(FString serverUri, FString username, F
 
 void UPubSubCommunicator::StartFileSaveClient(FString directoryPath, int maxMsgsPerSecond)
 {
+	ApplyParkedCarsOverride(publishParkedCarData_);
 	publisher_ = TSharedPtr<IPublisher>(
 		new FilePublisher(
 			TCHAR_TO_UTF8(*directoryPath),

--- a/Source/CiThruS/ViewSynthesis/PubSubCommunicator.h
+++ b/Source/CiThruS/ViewSynthesis/PubSubCommunicator.h
@@ -98,7 +98,7 @@ private:
 
 	inline static bool publishEgoVehicleData_ = true;
 	inline static bool publishCarData_ = true;
-	inline static bool publishParkedCarData_ = true;
+	inline static bool publishParkedCarData_ = false;
 	inline static bool publishPedestrianData_ = true;
 	inline static bool publishCyclistData_ = true;
 


### PR DESCRIPTION
- In VideoTransmitter.cpp, VideoTransmitter.cpp, and VideoTransmitter.h, the sender now has an explicit `streamFrameRate_` and only captures when one frame interval has elapsed. `StartTransmit()` also forces the engine/max FPS to that rate. This is the 60 FPS lock that made the stream stable.

- In HevcEncoder.cpp and HevcEncoder.h, the encoder now receives the frame rate, configures Kvazaar with that rate, and stamps frames with monotonic `pts/dts = frameIndex_` instead of the old wall-clock attempt. This keeps encoder timing consistent with the actual send cadence.

- In RtpTransmitter.cpp and RtpTransmitter.h, the RTP stream is configured with the same FPS numerator/denominator so transport timing matches the encoder timing.

- In RgbaToYuvConverter.cpp and HevcEncoder.cpp, output pins are explicitly cleared when there is no fresh input frame. This matters because the async pipeline keeps running continuously; without clearing the pins it could keep reusing the previous converted/encoded frame and re-send stale data between real captures.

- In PubSubCommunicator.h, by default, sending of ParkedCar data is false. In PubSubCommunicator.cpp added startup command to enable sending of ParkedCar data.